### PR TITLE
Fixed edge case where ecid may start with 0x

### DIFF
--- a/src/main/java/airsquared/blobsaver/app/TSS.java
+++ b/src/main/java/airsquared/blobsaver/app/TSS.java
@@ -387,11 +387,11 @@ public class TSS extends Task<String> {
             }
         }
     }
-
+    
     private void saveBlobsTSSSaver(StringBuilder responseBuilder) {
         Map<Object, Object> deviceParameters = new HashMap<>();
 
-        deviceParameters.put("ecid", String.valueOf(Long.parseLong(ecid, 16)));
+        deviceParameters.put("ecid", String.valueOf(Long.parseLong(ecid.startsWith("0x") ? ecid.substring(2) : ecid, 16)));
         deviceParameters.put("deviceIdentifier", deviceIdentifier);
         deviceParameters.put("boardConfig", getBoardConfig());
 


### PR DESCRIPTION
### When using a program such as [checkra1n](https://checkra.in/) the ecid may start with 0x. 
This causes the exception seen  below. I wrote this quick patch, it is untested but the general idea should be there. My actual ecid is the only piece of information I spoofed in the exception below.

```
java.lang.NumberFormatException: For input string: "0x123431234501E" under radix 16
	at java.base/java.lang.NumberFormatException.forInputString(Unknown Source)
	at java.base/java.lang.Long.parseLong(Unknown Source)
	at airsquared.blobsaver@3.3.0/airsquared.blobsaver.app.TSS.saveBlobsTSSSaver(Unknown Source)
	at airsquared.blobsaver@3.3.0/airsquared.blobsaver.app.TSS.call(Unknown Source)
	at airsquared.blobsaver@3.3.0/airsquared.blobsaver.app.TSS.call(Unknown Source)
	at javafx.graphics@19/javafx.concurrent.Task$TaskCallable.call(Unknown Source)
	at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```